### PR TITLE
Add Google Sheets to AWS S3 copy function

### DIFF
--- a/route1io_connectors/google/gsheets.py
+++ b/route1io_connectors/google/gsheets.py
@@ -7,6 +7,7 @@ import tempfile
 import pandas as pd
 from googleapiclient.discovery import build
 
+from .. import aws
 
 def upload_gsheets_spreadsheet(gsheets_conn: "googleapiclient.discovery.Resource",
                                filename: str, spreadsheet_id: str,
@@ -102,3 +103,13 @@ def copy_sheet_to_aws_s3(gsheets_conn: "googleapiclient.discovery.Resource",
     spreadsheet_id: str, spreadsheet_name: str, s3, bucket: str,
     key: str = None) -> None:
     """Copy file at given Google Sheet to S3 bucket"""
+    if key is None:
+        key = f"{spreadsheet_name}.csv"
+    with tempfile.NamedTemporaryFile("wb+") as outfile:
+        download_gsheets_spreadsheet(
+            gsheets_conn=gsheets_conn,
+            spreadsheet_id=spreadsheet_id,
+            spreadsheet_name=spreadsheet_name,
+            filename=outfile.name
+        )
+        aws.upload_to_s3(s3=s3, bucket=bucket, filename=outfile.name, key=key)

--- a/route1io_connectors/google/gsheets.py
+++ b/route1io_connectors/google/gsheets.py
@@ -95,3 +95,8 @@ def download_gsheets_spreadsheet(gsheets_conn: "googleapiclient.discovery.Resour
     values = result.get('values', [])
     df = pd.DataFrame(values[1:], columns=values[0])
     df.to_csv(filename, index=False)
+
+def copy_sheet_to_aws_s3(gsheets_conn: "googleapiclient.discovery.Resource",
+    spreadsheet_id: str, spreadsheet_name: str, s3, bucket: str, key: str) -> None:
+    """Copy file at given Google Sheet to S3 bucket"""
+    pass

--- a/route1io_connectors/google/gsheets.py
+++ b/route1io_connectors/google/gsheets.py
@@ -2,6 +2,8 @@
 
 This module contains functions for interacting with Google Sheets
 """
+import tempfile
+
 import pandas as pd
 from googleapiclient.discovery import build
 
@@ -97,6 +99,5 @@ def download_gsheets_spreadsheet(gsheets_conn: "googleapiclient.discovery.Resour
     df.to_csv(filename, index=False)
 
 def copy_sheet_to_aws_s3(gsheets_conn: "googleapiclient.discovery.Resource",
-    spreadsheet_id: str, spreadsheet_name: str, s3, bucket: str, key: str) -> None:
+    spreadsheet_id: str, spreadsheet_name: str, s3, bucket: str, key: str = None) -> None:
     """Copy file at given Google Sheet to S3 bucket"""
-    pass

--- a/route1io_connectors/google/gsheets.py
+++ b/route1io_connectors/google/gsheets.py
@@ -102,7 +102,24 @@ def download_gsheets_spreadsheet(gsheets_conn: "googleapiclient.discovery.Resour
 def copy_sheet_to_aws_s3(gsheets_conn: "googleapiclient.discovery.Resource",
     spreadsheet_id: str, spreadsheet_name: str, s3, bucket: str,
     key: str = None) -> None:
-    """Copy file at given Google Sheet to S3 bucket"""
+    """Copy file at given Google Sheet to S3 bucket
+
+    Parameters
+    ----------
+    gsheets_conn : googleapiclient.discovery.Resource
+        Connection to Google Sheets API
+    spreadsheet_id : str
+        ID of the Google Sheet to download from
+    spreadsheet_name : str
+        Name of the specific Sheet to write to
+    s3
+        Valid S3 connection created using aws.connect_to_s3
+    bucket : str
+        Existing bucket on AWS
+    key : str = None
+        (Optional) Key name of the file as it will appear in S3. If left blank
+        it will default to the same name that's in OneDrive
+    """
     if key is None:
         key = f"{spreadsheet_name}.csv"
     with tempfile.NamedTemporaryFile("wb+") as outfile:

--- a/route1io_connectors/google/gsheets.py
+++ b/route1io_connectors/google/gsheets.py
@@ -99,5 +99,6 @@ def download_gsheets_spreadsheet(gsheets_conn: "googleapiclient.discovery.Resour
     df.to_csv(filename, index=False)
 
 def copy_sheet_to_aws_s3(gsheets_conn: "googleapiclient.discovery.Resource",
-    spreadsheet_id: str, spreadsheet_name: str, s3, bucket: str, key: str = None) -> None:
+    spreadsheet_id: str, spreadsheet_name: str, s3, bucket: str,
+    key: str = None) -> None:
     """Copy file at given Google Sheet to S3 bucket"""

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = HERE.joinpath("README.md").read_text()
 
 setup(
     name="route1io-connectors",
-    version="0.9.0",
+    version="0.10.0",
     description="Connectors for interacting with popular API's used in marketing analytics using clean and concise Python code.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Description
Creating function for mapping directly from Google Sheets over to AWS. NOTE: currently only supporting tabular data that match CSV format

Fixes #18 
