### PR TITLE
Add warning to Google Analytics connector that ga4=True will become the default behavior in a future update

### DIFF
--- a/route1io_connectors/google/google_analytics.py
+++ b/route1io_connectors/google/google_analytics.py
@@ -26,6 +26,7 @@ def connect_to_google_analytics(
     google_conn : googleapiclient.discovery.Resource
         Connection to Google Analytics API
     """
+    warnings.warn("In the future ga4=True will become the default behavior for this function. Google is sunsetting Universal Analytics on July 1st, 2023 and is recommending you migrate to Google Analytics 4. More information can be found here: https://support.google.com/analytics/answer/11583528?hl=en", FutureWarning)
     if ga4: 
         google_conn = BetaAnalyticsDataClient(credentials=credentials)
     else:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = HERE.joinpath("README.md").read_text()
 
 setup(
     name="route1io-connectors",
-    version="0.15.0",
+    version="0.15.1",
     description="Connectors for interacting with popular API's used in marketing analytics using clean and concise Python code.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Description
Add `FutureWarning` that `ga4=True` will become the default functionality in a future update after Universal Analytics is sunsetted
